### PR TITLE
Feature/fix xframe headers

### DIFF
--- a/GUI/nginx/default.conf
+++ b/GUI/nginx/default.conf
@@ -1,5 +1,5 @@
 server {
-
+  add_header X-Frame-Options "DENY";
   listen 80;
 
   sendfile on;

--- a/GUI/nginx/default.conf
+++ b/GUI/nginx/default.conf
@@ -1,11 +1,11 @@
 server {
-  add_header X-Frame-Options "DENY";
+  
   listen 80;
 
   sendfile on;
 
   default_type application/octet-stream;
-
+  add_header X-Frame-Options "DENY";
 
   gzip on;
   gzip_http_version 1.1;


### PR DESCRIPTION
This should fix X-frame protection, not allowing the vulnmanager to be framed somewhere else than on itself.